### PR TITLE
fix(socc.py): moved hard-coded params to function arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,13 +72,14 @@ Read the [CONTRIBUTING.md](CONTRIBUTING.md) file.
 Cite our work if you find it useful
 
 ```bibtex
-@article{NG2024SOccDPT,
-  title={SOccDPT: 3D Semantic Occupancy from Dense Prediction Transformers trained under memory constraints},
-  author={NG, Aditya},
-  journal={Advances in Artificial Intelligence and Machine Learning},
-  volume={ISSN: 2582-9793, Source Id: 21101164612},
-  year={2024},
-  url={https://www.oajaiml.com/}
+@article{nalgunda2024soccdpt,
+  author = {Aditya Nalgunda Ganesh},
+  title = {SOccDPT: 3D Semantic Occupancy from Dense Prediction Transformers trained under memory constraints},
+  journal = {Advances in Artificial Intelligence and Machine Learning},
+  volume = {4},
+  number = {2},
+  pages = {2201--2212},
+  year = {2024}
 }
 ``` 
 


### PR DESCRIPTION
### Summary :memo:
The `get_socc` function has quite a few parameters which are hard-coded.
It becomes difficult to use this function. As a result, I am moving these to function arguments

### Details
_Describe more what you did on changes._
1. scale defaults aligned
2. point scaling aligned
3. baseline added
4. clip_range added
5. voxel_size added
6. occupancy_threshold added

### Checks
- [ ] Tested Changes
- [ ] Stakeholder Approval
